### PR TITLE
Add support for wrangler.jsonc

### DIFF
--- a/package.json
+++ b/package.json
@@ -2646,7 +2646,10 @@
       },
       {
         "url": "https://www.unpkg.com/wrangler/config-schema.json",
-        "fileMatch": "wrangler.json"
+        "fileMatch": [
+          "wrangler.json",
+          "wrangler.jsonc"
+        ]
       },
       {
         "url": "https://www.updatecli.io/schema/latest/policy/manifest/config.json",


### PR DESCRIPTION
Cloudflare recommends using `wrangler.jsonc` for new projects (https://developers.cloudflare.com/workers/wrangler/configuration/) so add support for this filename.